### PR TITLE
Relax the required version of test-kitchen

### DIFF
--- a/kitchen-shopify-provisioner.gemspec
+++ b/kitchen-shopify-provisioner.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'chef',         ['~> 12']
-  s.add_runtime_dependency 'test-kitchen', ['~> 1.9']
+  s.add_runtime_dependency 'test-kitchen', ['~> 1.7']
   s.add_development_dependency 'rspec', ['~> 3.4']
   s.add_development_dependency 'rake', ['~> 10.4']
 end

--- a/lib/kitchen-shopify-provisioner/version.rb
+++ b/lib/kitchen-shopify-provisioner/version.rb
@@ -1,3 +1,3 @@
 module KitchenShopifyProvisioner
-  VERSION = '0.0.3'
+  VERSION = '0.0.4'
 end


### PR DESCRIPTION
The current ChefDK ships with Test-Kitchen 1.8.0, and there are likely
folks also using older versions.  Let's relax the version constraints so
that folks can use the ChefDK with this gem.,

@dalehamel @dwradcliffe can you review and push up to rubygems?
