### PR TITLE
Avoid exceptions when roles_path unset

### DIFF
--- a/lib/kitchen/provisioner/chef_zero_shopify.rb
+++ b/lib/kitchen/provisioner/chef_zero_shopify.rb
@@ -15,14 +15,20 @@ module Kitchen
           FileUtils.rm_rf(tmpdir)
         end
 
-        Dir.glob(File.join(config[:roles_path], '**', '*.rb')).each do |rb_file|
-          obj = ::Chef::Role.new
-          obj.from_file(rb_file)
-          json_file = rb_file.sub(/\.rb$/, '.json').gsub(config[:roles_path], '').sub(/^\//, '').split('/').join('--')
-          File.write(File.join(tmpdir, json_file), ::Chef::JSONCompat.to_json_pretty(obj))
+        # This block generates exceptions if we don't have a roles directory in ./
+        #   or :roles_path is not configured in .kitchen.yml.  So just call the
+        #   superclass version and be done with it.
+        unless config[:roles_path].nil?
+          Dir.glob(File.join(config[:roles_path], '**', '*.rb')).each do |rb_file|
+            obj = ::Chef::Role.new
+            obj.from_file(rb_file)
+            json_file = rb_file.sub(/\.rb$/, '.json').gsub(config[:roles_path], '').sub(/^\//, '').split('/').join('--')
+            File.write(File.join(tmpdir, json_file), ::Chef::JSONCompat.to_json_pretty(obj))
+          end
+
+          config[:roles_path] = tmpdir
         end
 
-        config[:roles_path] = tmpdir
         super
       end
     end


### PR DESCRIPTION
roles_path is only set if a `roles` directory is present in the current
directory, or if it is set explicity.  So we guard against exceptions by
checking that roles_path is not nil before globbing its path.

@dwradcliffe @dalehamel 
