### PR TITLE
Plain data bags

### DIFF
--- a/kitchen-shopify-provisioner.gemspec
+++ b/kitchen-shopify-provisioner.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |s|
   s.description = s.summary
   s.homepage    = 'https://github.com/shopify/kitchen-shopify-provisioner'
 
-  s.files         = `git ls-files`.split($/)
-  s.test_files    = s.files.grep(%r{spec})
+  s.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  s.test_files    = s.files.grep(/spec/)
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'chef',         ['~> 12']

--- a/lib/kitchen-shopify-provisioner/version.rb
+++ b/lib/kitchen-shopify-provisioner/version.rb
@@ -1,3 +1,3 @@
 module KitchenShopifyProvisioner
-  VERSION = '0.0.4'
+  VERSION = '0.0.4'.freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 RSpec.configure do |config|
-  config.order = "random"
-  config.expect_with(:rspec) {|c| c.syntax = :expect }
+  config.order = 'random'
+  config.expect_with(:rspec) { |c| c.syntax = :expect }
 end
 
 class BogusInstance


### PR DESCRIPTION
@dwradcliffe @stonith @andrewjamesbrown for review

I encountered an issue where some cookbooks (in this case, the upstream users cookbook) attempt to search data bags for a particular value. As the data bags are encrypted, this search returns nothing.

As we also have a few instances in our own cookbooks where this is an issue, this patch seems necessary to ensure that we get the correct behavior.

The code here was lifted mostly from https://github.com/dalehamel/chefdepartie/blob/master/lib/chefdepartie/databag.rb, which was originally lifted from cooker.
