### PR TITLE
UGH

### DIFF
--- a/lib/kitchen-shopify-provisioner/databag_mash_monkeypatch.rb
+++ b/lib/kitchen-shopify-provisioner/databag_mash_monkeypatch.rb
@@ -1,0 +1,33 @@
+# because https://github.com/chef/chef-zero/pull/147/files will never get merged
+
+module ChefZero
+  module ChefData
+    class DataNormalizer
+      def self.normalize_data_bag_item(data_bag_item, data_bag_name, id, method)
+        if method == 'DELETE'
+          # TODO SERIOUSLY, WHO DOES THIS MANY EXCEPTIONS IN THEIR INTERFACE
+          unless data_bag_item['json_class'] == 'Chef::DataBagItem' && data_bag_item['raw_data']
+            data_bag_item['id'] ||= id
+            data_bag_item = { 'raw_data' => data_bag_item }
+            data_bag_item['chef_type'] ||= 'data_bag_item'
+            data_bag_item['json_class'] ||= 'Chef::DataBagItem'
+            data_bag_item['data_bag'] ||= data_bag_name
+            data_bag_item['name'] ||= "data_bag_item_#{data_bag_name}_#{id}"
+          end
+        else
+          # If it's not already wrapped with raw_data, wrap it.
+          if data_bag_item['json_class'] == 'Chef::DataBagItem' && data_bag_item['raw_data']
+            # data_bag_item = data_bag_item['raw_data']
+          end
+          # Argh.  We don't do this on GET, but we do on PUT and POST????
+          if %w(PUT POST).include?(method)
+            data_bag_item['chef_type'] ||= 'data_bag_item'
+            data_bag_item['data_bag'] ||= data_bag_name
+          end
+          data_bag_item['id'] ||= id
+        end
+        data_bag_item
+      end
+    end
+  end
+end

--- a/lib/kitchen/provisioner/chef_zero_shopify.rb
+++ b/lib/kitchen/provisioner/chef_zero_shopify.rb
@@ -5,6 +5,9 @@ require 'chef/data_bag_item'
 require 'chef/encrypted_data_bag_item'
 require 'chef/encrypted_data_bag_item/check_encrypted'
 
+# UGH
+require 'kitchen-shopify-provisioner/databag_mash_monkeypatch'
+
 module Kitchen
   module Provisioner
     # We'll sneak some code in before the default chef zero provisioner runs

--- a/lib/kitchen/provisioner/chef_zero_shopify.rb
+++ b/lib/kitchen/provisioner/chef_zero_shopify.rb
@@ -65,7 +65,10 @@ module Kitchen
           files.each do |item_file|
             raw_data = ::Chef::JSONCompat.from_json(IO.read(item_file))
             raw_data = ::Chef::EncryptedDataBagItem.new(raw_data, secret).to_hash if encrypted_data_bag?(raw_data)
-            json_dump = ::Chef::JSONCompat.to_json_pretty(raw_data)
+            item = ::Chef::DataBagItem.new
+            item.data_bag(bag_name)
+            item.raw_data = raw_data
+            json_dump = ::Chef::JSONCompat.to_json_pretty(item)
             plain_file = File.join(plain_data_bags, bag_name, File.basename(item_file))
             FileUtils.mkdir_p(File.dirname(plain_file))
             File.write(plain_file, json_dump)


### PR DESCRIPTION
![sad panda](https://media.giphy.com/media/3e18NPUVzoxzO/giphy.gif)

@dwradcliffe @andrewjamesbrown 

tl;dr chef-zero returns non-mash data for data bags. because it's being braindead and losing the data bag type. It treats the data bag data thus as a plain hash instead of a mash.

Our code depends on it being a mash.

this is dirty, i know, but because of https://github.com/chef/chef-zero/pull/147 this is necessary.
