### PR TITLE
Preserve json type

### DIFF
--- a/lib/kitchen/provisioner/chef_zero_shopify.rb
+++ b/lib/kitchen/provisioner/chef_zero_shopify.rb
@@ -62,7 +62,10 @@ module Kitchen
           files.each do |item_file|
             raw_data = ::Chef::JSONCompat.from_json(IO.read(item_file))
             raw_data = ::Chef::EncryptedDataBagItem.new(raw_data, secret).to_hash if encrypted_data_bag?(raw_data)
-            json_dump = ::Chef::JSONCompat.to_json_pretty(raw_data)
+            item = ::Chef::DataBagItem.new
+            item.data_bag(bag_name)
+            item.raw_data = raw_data
+            json_dump = ::Chef::JSONCompat.to_json_pretty(item)
             plain_file = File.join(plain_data_bags, bag_name, File.basename(item_file))
             FileUtils.mkdir_p(File.dirname(plain_file))
             File.write(plain_file, json_dump)


### PR DESCRIPTION
@andrewjamesbrown @dwradcliffe this is in favor of https://github.com/Shopify/kitchen-shopify-provisioner/pull/6

This will at least preserve the json type of the data bag objects. From there, we can :monkey: patch in our cookbooks, or deal with this in some other way.
