### PR TITLE
Timestamps can be helpful

### DIFF
--- a/lib/kitchen/logger.rb
+++ b/lib/kitchen/logger.rb
@@ -1,0 +1,15 @@
+module Kitchen
+  class Logger
+    alias_method :old_stdout_logger, :stdout_logger
+    def stdout_logger(*args)
+      logger = old_stdout_logger(*args)
+      old_formatter = logger.formatter
+      if ENV['LOG_TIMESTAMPS']
+        logger.formatter = proc do |_severity, _datetime, _progname, msg|
+          "[#{_datetime}] #{old_formatter.call(_severity, _datetime, _progname, msg)}"
+        end
+      end
+      logger
+    end
+  end
+end


### PR DESCRIPTION
There is probably a better way to trigger this than `ENV['LOG_TIMESTAMPS']` 

This should be less likely to break as Kitchen::Logger changes.
@Shopify/metalscale 
